### PR TITLE
Add test action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,10 @@ name: Deploy Kotlin App to EKS
 on:
   push:
     branches: "*"
+  workflow_run:
+    workflows: ["Deploy"]
+    types:
+      - completed
 
 env:
   AWS_REGION: us-east-1
@@ -11,6 +15,9 @@ env:
 
 jobs:
   deploy:
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,13 +55,14 @@ jobs:
 
       - name: Deploy to EKS
         run: |
-          sed -i "s|techfood-products/kotlin-app:latest|${{ steps.login-ecr.outputs.registry }}/$ECR_REPOSITORY:${{ github.sha }}|" kubernetes/deployment-app.yaml
-          kubectl apply -f kubernetes/secrets.yaml
-          kubectl apply -f kubernetes/config-db.yaml
-          kubectl apply -f kubernetes/pv-db.yaml
-          kubectl apply -f kubernetes/pvc-db.yaml
-          kubectl apply -f kubernetes/deployment-db.yaml
-          kubectl apply -f kubernetes/service-db.yaml
-          kubectl apply -f kubernetes/deployment-app.yaml
-          kubectl apply -f kubernetes/service-app.yaml
-          kubectl apply -f kubernetes/hpa-app.yaml
+          sed -i "s|techfood-products/kotlin-app:latest|${{ steps.login-ecr.outputs.registry }}/$ECR_REPOSITORY:${{ github.sha }}|" kubernetes/manifests/deployment-app.yaml
+          kubectl create namespace techfood-produtos --dry-run=client -o yaml | kubectl apply -f -
+          kubectl apply -f kubernetes/manifests/secrets.yaml
+          kubectl apply -f kubernetes/manifests/config-db.yaml
+          kubectl apply -f kubernetes/manifests/pv-db.yaml
+          kubectl apply -f kubernetes/manifests/pvc-db.yaml
+          kubectl apply -f kubernetes/manifests/deployment-db.yaml
+          kubectl apply -f kubernetes/manifests/service-db.yaml
+          kubectl apply -f kubernetes/manifests/deployment-app.yaml
+          kubectl apply -f kubernetes/manifests/service-app.yaml
+          kubectl apply -f kubernetes/manifests/hpa-app.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,36 @@
+name: Test & Coverage
+
+on:
+  push:
+    branches: ["*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests with coverage
+        run: ./gradlew test jacocoTestReport
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-reports
+          path: build/reports/jacoco/
+
+      - name: Check coverage minimum threshold
+        run: ./gradlew jacocoTestCoverageVerification

--- a/kubernetes/manifests/service-app.yaml
+++ b/kubernetes/manifests/service-app.yaml
@@ -7,8 +7,8 @@ spec:
   type: NodePort
   ports:
     - protocol: TCP
-      port: 8082        # Porta do serviço no Kubernetes
-      targetPort: 8082  # Porta interna do container
-      nodePort: 30082   # Porta exposta na máquina host (para acesso externo)
+      port: 8082 # Porta do serviço no Kubernetes
+      targetPort: 8082 # Porta interna do container
+      nodePort: 30084 # Porta exposta na máquina host (para acesso externo)
   selector:
     app: techfood-produtos-app


### PR DESCRIPTION
This pull request includes significant updates to the deployment and testing workflows for the Kotlin application, as well as a minor change to the Kubernetes service configuration. The most important changes include adding a new test workflow, updating the deployment workflow to support workflow runs, and modifying the Kubernetes manifest paths.

Improvements to workflows:

* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R6-R9): Added support for `workflow_run` events and updated the deployment job to run only on successful completion of the specified events. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R6-R9) [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R18-R20)
* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L51-R68): Modified the deployment steps to use the correct paths for Kubernetes manifests and added a step to create the namespace if it doesn't exist.
* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692R1-R36): Introduced a new workflow for testing and coverage, including steps for setting up JDK 17, running tests with coverage, and uploading coverage reports.

Kubernetes configuration update:

* [`kubernetes/manifests/service-app.yaml`](diffhunk://#diff-4696bc5578221aeba4f916d6fe97f077155606999cd6a6bbddfe392965388e28L12-R12): Changed the `nodePort` from `30082` to `30084` for the exposed port on the host machine.